### PR TITLE
Fix downloaded filenames

### DIFF
--- a/hosts/DownloadClass.php
+++ b/hosts/DownloadClass.php
@@ -72,7 +72,7 @@ class DownloadClass {
 		$url = parse_url($link);
 		$params = $this->DefaultParamArr($link, $cookie, $referer, true);
 		unset($params['premium_acc']);
-		$params['filename'] = urlencode((!empty($FileName) ? basename($FileName) : urldecode(basename(parse_url($link, PHP_URL_PATH)))));
+		$params['filename'] = urlencode((!empty($FileName) ? urldecode(basename($FileName)) : urldecode(basename(parse_url($link, PHP_URL_PATH)))));
 		if (!empty($force_name)) $params['force_name'] = urlencode(basename($force_name));
 		$params['host'] = urlencode($url['host']);
 		if (!empty($url['port'])) $params['port'] = urlencode($url['port']);


### PR DESCRIPTION
Seems that filenames are URL-encoded twice (often only some characters, such as parenthesis), so web browsers cannot recognize filenames.
This happens when the method 'RedirectDownload()' receive an URL-encoded $FileName.
To fix simply URL-decode also the $FileName value.